### PR TITLE
Added travis files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,9 @@ deploy:
   on:
     branch: master
   local_dir: docs
+addons:
+  apt:
+    packages:
+      - librdf0-dev
+      - libnetcdf-dev
+      - r-cran-ncdf4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: r
+pandoc_version: 2.1.1
+sudo: false
+cache: packages
+script:
+  - Rscript -e 'bookdown::render_book("index.Rmd", "bookdown::gitbook")'
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN #set in travis-ci dashboard
+  on:
+    branch: master
+  local_dir: docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ script:
   - Rscript -e 'bookdown::render_book("index.Rmd", "bookdown::gitbook")'
 deploy:
   provider: pages
+  edge:
+    branch: pages-ivar-set
   skip_cleanup: true
   github_token: $GITHUB_TOKEN #set in travis-ci dashboard
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ script:
   - Rscript -e 'bookdown::render_book("index.Rmd", "bookdown::gitbook")'
 deploy:
   provider: pages
-  edge:
-    branch: pages-ivar-set
   skip_cleanup: true
   github_token: $GITHUB_TOKEN #set in travis-ci dashboard
   on:

--- a/08_Nesting.Rmd
+++ b/08_Nesting.Rmd
@@ -6,7 +6,7 @@ knitr::opts_chunk$set(eval = F)
 
 ## Introduction  
 
-This document is a practical tutorial for creating nesting relationships between data packages on the DataONE member nodes (MNs).  
+This document is a tutorial for creating nesting relationships between data packages on the DataONE member nodes (MNs). 
 
 Data packages on MNs can exist as independent packages or in groups (nested data packages). Much like we can group multiple data files together with a common metadata file, we can group related data packages together with a common "parent" data package.  
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,10 @@
+Package: placeholder
+Title: Placeholder
+Author: Placeholder
+Maintainer: Placeholder <developer@some.domain.net>
+Description: This is a description. 
+Version: 0.0.1
+Imports: bookdown, xfun, rmarkdown, tidyverse, arcticdatautils, EML, dataone
+Remotes: rstudio/bookdown, NCEAS/arcticdatautils
+License: GPL-2
+RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,8 @@ Maintainer: Placeholder <developer@some.domain.net>
 Description: This is a description. 
 Version: 0.0.1
 Imports: bookdown, xfun, rmarkdown, tidyverse, arcticdatautils, EML, dataone
-Remotes: rstudio/bookdown, NCEAS/arcticdatautils
-License: GPL-2
+Remotes: rstudio/bookdown, NCEAS/arcticdatautils@*release
+License: Apache License (== 2.0)
 RoxygenNote: 6.0.1
+LazyData: true
+Encoding: UTF-8

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -4,3 +4,5 @@ language:
     chapter_name: "Chapter "
 delete_merged_file: true
 output_dir: "docs"
+new_session: no
+delete_merged_file: true

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -5,4 +5,3 @@ language:
 delete_merged_file: true
 output_dir: "docs"
 new_session: no
-delete_merged_file: true

--- a/_output.yml
+++ b/_output.yml
@@ -1,0 +1,17 @@
+bookdown::gitbook:
+  css: style.css
+  split_by: chapter
+  config:
+    toc:
+      collapse: subsection
+      before: |
+        <li><a href="./">Data Team Training</a></li>
+      after: |
+        <li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>
+bookdown::pdf_book:
+  includes:
+    in_header: preamble.tex
+  latex_engine: xelatex
+  citation_package: natbib
+bookdown::epub_book:
+  stylesheet: style.css


### PR DESCRIPTION
Added Travis files for continuous integration (every time we change an Rmd, Travis rebuilds the book).

To make it work, we need to add tokens/etc to link Travis to GitHub (steps 1-3, https://github.com/isteves/two-bookdowns-example).

A small change to the Nesting chapter was used to test that the rebuild works.