### PR TITLE
adding rawToChar to read eml in section 5.1

### DIFF
--- a/workflows/edit_data_packages/get_package_and_eml.Rmd
+++ b/workflows/edit_data_packages/get_package_and_eml.Rmd
@@ -13,7 +13,7 @@ pkg <- get_package(adc_test,
 After loading the package, you can also load the EML file into R using the following command:
 
 ``` {r, eval = FALSE}
-eml <- read_eml(getObject(adc_test, pkg$metadata))
+eml <- read_eml(rawToChar(getObject(adc_test, pkg$metadata)))
 ```
 
 ```{block, type = 'note'}


### PR DESCRIPTION
When add an error when running code in section 5.1. I added `rawToChar` to fix this.

Note I have not rebuilt the site as I am not sure of your workflow; just updated the markdown.