### PR TITLE
Added enhancements to training

### DIFF
--- a/workflows/explore_eml/access_specific_elements.Rmd
+++ b/workflows/explore_eml/access_specific_elements.Rmd
@@ -33,10 +33,26 @@ eml_get(doc, "url")
 '': ecogrid://knb/urn:uuid:89bec5d0-26db-48ac-ae54-e1b4c999c456
 ```
 
-You can also use the `which_in_eml()` function from the `datamgmt` package to get indices within an EML list. Here is an example:
+`eml_get_simple()` is a simplified alternative to `eml_get()`. Produces a list of the desired EML element.
+
+```{r "eml_get_simple", eval = FALSE}
+eml_get_simple(doc$dataset$otherEntity, "entityName")
+```
+
+To find an eml element you can use either a combination of `which_in_eml`from the `datamgmt` package or `eml_get_simple` and `which` to find the index in an EML list. Use which ever workflow you see 
+fit.
+
+Example using `which_in_eml`:
 
 ```{r "which_in_eml", eval = FALSE}
 # Question: Which creators have a surName "Mecum"?
 n <- which_in_eml(doc$dataset$creator, "surName", "Mecum")
 # Answer: doc$dataset$creator[[n]]
+```
+
+Example using `eml_get_simple` and `which`:
+
+```{r "getting index using eml_get_simple" eval = FALSE}
+ent_names <- eml_get_simple(doc$dataset$creator, "surName")
+i <- which(ent_names == "Mecum")
 ```

--- a/workflows/explore_eml/access_specific_elements.Rmd
+++ b/workflows/explore_eml/access_specific_elements.Rmd
@@ -33,7 +33,7 @@ eml_get(doc, "url")
 '': ecogrid://knb/urn:uuid:89bec5d0-26db-48ac-ae54-e1b4c999c456
 ```
 
-`eml_get_simple()` is a simplified alternative to `eml_get()`. Produces a list of the desired EML element.
+`eml_get_simple()` is a simplified alternative to `eml_get()` that produces a list of the desired EML element.
 
 ```{r "eml_get_simple", eval = FALSE}
 eml_get_simple(doc$dataset$otherEntity, "entityName")
@@ -42,17 +42,19 @@ eml_get_simple(doc$dataset$otherEntity, "entityName")
 To find an eml element you can use either a combination of `which_in_eml`from the `datamgmt` package or `eml_get_simple` and `which` to find the index in an EML list. Use which ever workflow you see 
 fit.
 
+**An example question you may have:** *Which creators have a surName "Mecum"?*
+
 Example using `which_in_eml`:
 
 ```{r "which_in_eml", eval = FALSE}
-# Question: Which creators have a surName "Mecum"?
 n <- which_in_eml(doc$dataset$creator, "surName", "Mecum")
 # Answer: doc$dataset$creator[[n]]
 ```
 
 Example using `eml_get_simple` and `which`:
 
-```{r "getting index using eml_get_simple" eval = FALSE}
+```{r "getting index using eml_get_simple", eval = FALSE}
 ent_names <- eml_get_simple(doc$dataset$creator, "surName")
 i <- which(ent_names == "Mecum")
+# Answer: doc$dataset$creator[[i]]
 ```

--- a/workflows/explore_eml/access_specific_elements.Rmd
+++ b/workflows/explore_eml/access_specific_elements.Rmd
@@ -39,7 +39,7 @@ eml_get(doc, "url")
 eml_get_simple(doc$dataset$otherEntity, "entityName")
 ```
 
-To find an eml element you can use either a combination of `which_in_eml`from the `datamgmt` package or `eml_get_simple` and `which` to find the index in an EML list. Use which ever workflow you see 
+To find an eml element you can use either a combination of `which_in_eml`from the `arcticdatautils` package or `eml_get_simple` and `which` to find the index in an EML list. Use which ever workflow you see 
 fit.
 
 **An example question you may have:** *Which creators have a surName "Mecum"?*

--- a/workflows/nesting_data/nesting_a_data_package.Rmd
+++ b/workflows/nesting_data/nesting_a_data_package.Rmd
@@ -1,4 +1,4 @@
-# Nesting a data package
+## Nesting a data package
 
 ```{r, setup, include=FALSE}
 knitr::opts_chunk$set(collapse = TRUE)


### PR DESCRIPTION
addresses #130

- `get_eml_simple()` added as an alternative to just `get_eml()` with examples of how to use it
- fixed sidebar hierarchy issues for the newly moved Nesting chapters