### PR TITLE
Fixed two errors in section 1.9

### DIFF
--- a/training/01_introduction.Rmd
+++ b/training/01_introduction.Rmd
@@ -98,7 +98,7 @@ doc_ex <- list(packageId = "id", system = "system",
 ## A note on Exercises
 The rest of the training has a series of exercises. These are meant to take you through the process as someone submitting a dataset from scratch. This is slightly different than the usual workflow but important in understanding the underlying system behind the Arctic Data Center.
 
-Please note that you will be completing everything on the  <a href = 'test.arcticdata.io' target='_blank'> site for the training. In the future if you are unsure about doing anything with a dataset. The test site is a good place to try things out!
+Please note that you will be completing everything on the  <a href = 'https://test.arcticdata.io' target='_blank'> site</a> for the training. In the future if you are unsure about doing anything with a dataset. The test site is a good place to try things out!
 
 ## Exercise 1 {.exercise}
 This part of the exercise walks you through submitting data through the web form on "<a href = 'https://test.arcticdata.io' target='_blank'>test.arcticdata.io</a>"


### PR DESCRIPTION
1) 404 error due to missing "https://" …in URL for testarticdata.io
2) larger than intended (I think) hyperlink associated with the same URL due to missing "</a>".

<img width="908" alt="Screen Shot 2020-08-05 at 2 56 03 PM" src="https://user-images.githubusercontent.com/32374186/89453478-54893600-d72d-11ea-90f3-8b5fb769aef3.png">
