### PR TITLE
Updated metadata formatId example in Section 2.5 via 'publish_an_object.Rmd' 

### DIFF
--- a/workflows/edit_data_packages/publish_an_object.Rmd
+++ b/workflows/edit_data_packages/publish_an_object.Rmd
@@ -10,7 +10,7 @@ formatId <- "text/csv"
 formatId <- "text/plain"
 
 # metadata file
-formatId <- "eml://ecoinformatics.org/eml-2.2.0"
+formatId <- "https://eml.ecoinformatics.org/eml-2.2.0"
 # OR
 formatId <- format_eml("2.2.0")
 ```


### PR DESCRIPTION
Creating metadata PID from EML was throwing an error using the first formatId in the training (formatId <- "eml://ecoinformatics.org/eml-2.2.0"). Updated to use formatId from DataONE Object Format List (https://cn.dataone.org/cn/v2/formats).

<img width="1294" alt="Screen Shot 2020-08-06 at 3 06 55 PM" src="https://user-images.githubusercontent.com/32374186/89572620-5a4b4e00-d7f7-11ea-8a30-a9f14fc14819.png">
