### PR TITLE
Updates to 4.4.1 to allow using Shiny app to edit attributes.

### DIFF
--- a/workflows/edit_eml/edit_attributelists.Rmd
+++ b/workflows/edit_eml/edit_attributelists.Rmd
@@ -72,11 +72,16 @@ attributes <- data.frame(
 However, typing this out in R can be a major pain. Luckily, there's a Shiny app that you can use to build attribute information. You can use the app to build attributes from a data file loaded into R (recommended as the app will auto-fill some fields for you) to edit an existing attribute table, or to create attributes from scratch. Use the following commands to create or modify attributes (these commands will launch a Shiny app in your web browser):
 
 ```{r, eval = FALSE}
+#first download the CSV in your data package from Exercise #2
+data <- read.csv(text=rawToChar(getObject(adc_test, pkg$data)))
+```
+
+```{r, eval = FALSE}
 # From data (recommended)
 EML::shiny_attributes(data = data)
 
 # From an existing attribute table
-EML::shiny_attributes(attributes_table = attributes_table)
+EML::shiny_attributes(attributes = attributes)
 
 # From scratch
 atts <- EML::shiny_attributes()


### PR DESCRIPTION
1) added new code chunk to download CSV from the data package we uploaded in Exercise #2.
2) modified existing code to update argument called by EML::shiny_attributes from "attributes_table" to "attributes"
3)change the object referenced to call the attribute table created manually above in an earlier part of 4.4.1.

This is a partial fix to issue #192