### PR TITLE
Minor typo fixes to 4.13 within `set_parties.Rmd`

### DIFF
--- a/workflows/edit_eml/set_parties.Rmd
+++ b/workflows/edit_eml/set_parties.Rmd
@@ -23,7 +23,7 @@ JC_creator <- arcticdatautils::eml_creator(given_names = "Jeanette",
 doc$dataset$creator <- JC_creator
 ```
 
-Similarly, we can set the `contact`s. In this case, there are two, so we set `doc$dataset$contact` as a list containing both of them.
+Similarly, we can set a single `contact` or multiple. In this case, there are two, so we set `doc$dataset$contact` as a list containing both of them.
 
 ```{r, eval = FALSE}
 JC_contact <- arcticdatautils::eml_contact(given_names = "Jeanette", 
@@ -55,6 +55,6 @@ JG_ap <- arcticdatautils::eml_associated_party(given_names = "Jesse",
                                                phone = "123-456-7890",  
                                                address = NCEASadd, 
                                                userId = "https://orcid.org/WWWW-XXXX-YYYY-ZZZZ",
-                                               role = "metaataProvider")
+                                               role = "metadataProvider")
 doc$dataset$associatedParty <- JG_ap
 ```


### PR DESCRIPTION
1) Wording around `contact` redone to avoid using the "s".

<img width="901" alt="Screen Shot 2020-08-10 at 4 14 10 PM" src="https://user-images.githubusercontent.com/32374186/89826750-baf2c780-db24-11ea-842d-80e1a88787de.png">


2) "d" added to "metadataProvider"

<img width="906" alt="Screen Shot 2020-08-10 at 4 10 05 PM" src="https://user-images.githubusercontent.com/32374186/89826851-d6f66900-db24-11ea-9540-72fe9ec920d6.png">
