### PR TITLE
Clarifying shiny app and dataset annotations

### DIFF
--- a/workflows/edit_eml/edit_attributelists.Rmd
+++ b/workflows/edit_eml/edit_attributelists.Rmd
@@ -79,11 +79,11 @@ data <- read.csv(text=rawToChar(getObject(d1c_test@mn, data_pid)))
 
 ```{r, eval = FALSE}
 # From data (recommended)
-EML::shiny_attributes(data = data)
+atts <- EML::shiny_attributes(data = data)
 
 # From an existing attribute table
 attributeList <- get_attributes(doc$dataset$dataTable[[i]]$attributeList)
-EML::shiny_attributes(data = NULL, attributes = attributeList$attributes)
+atts <- EML::shiny_attributes(data = NULL, attributes = attributeList$attributes)
 
 # From scratch
 atts <- EML::shiny_attributes()
@@ -171,7 +171,7 @@ factors <- rbind(data.frame(attributeName = 'Location', code = names(Location), 
 Once you have built your attributes, factors, and custom units, you can add them to EML objects. Attributes and factors are combined to form an `attributeList` using the following command:
 
 ```{r, eval = FALSE}
-attributeList <- EML::set_attributes(attributes = attributes,
+attributeList <- EML::set_attributes(attributes = atts$attributes,
                                      factors = factors) 
 ```
 

--- a/workflows/edit_eml/edit_semantic_annotation.Rmd
+++ b/workflows/edit_eml/edit_semantic_annotation.Rmd
@@ -140,11 +140,15 @@ doc$dataset$dataTable[[3]]$attributeList$attribute[[6]]$annotation$valueURI <- l
 
 On the far right of the table of `shiny_attributes` there are 4 columns: `id`, `propertyURI`, `propertyLabel`, `valueURI`, `valueLabel` that can be filled out.
 
-### Annotating sensitive data
+### Dataset annotations
+
+In addition to attributes being assigned annotations, the overall dataset will also be annotated. The dataset will be given two categories of annotations: one for documenting how "sensitive" the data are, and one for documenting the overall academic discipline the dataset falls under.
+
+#### Annotating sensitive data
 
 Sensitive datasets that might cover protected characteristics (human subjects data, endangered species locations, etc) should be annotated using the data sensitivity ontology: https://bioportal.bioontology.org/ontologies/SENSO/?p=classes&conceptid=root. 
 
-#### Dataset Annotations
+#### Academic discipline annotations
 
 As a final step in the data processing pipeline, we will categorize the dataset. We are trying to categorize datasets so we can have a general idea of what kinds of data we have at the Arctic Data Center.
 


### PR DESCRIPTION
**Shiny app:** Added slightly more context to make sure future interns know that to save the output of `shiny_attributes()` to an object.

**Dataset annotations:** added a small introduction describing dataset-level annotations, and corrected the headers for the the "data sensitivity annotations" and "academic discipline annotations" headers.